### PR TITLE
Add support for b:disable_secure_modelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ The `g:secure_modelines_modelines` variable overrides the number of lines to che
 
 If `g:secure_modelines_leave_modeline` is defined, the script will not clobber &modeline. Otherwise &modeline will be unset.
 
+If `b:disable_secure_modelines` is defined, securemodelines will not run for the current buffer. The intent being to turn off securemodelines in an ftplugin.
+
 Keeping things up to date on vim.org is a nuisance. For the latest version, visit: http://github.com/ciaranm/securemodelines
 
 Install into your plugin directory of choice.

--- a/doc/securemodelines.txt
+++ b/doc/securemodelines.txt
@@ -57,6 +57,9 @@ to check. By default it is 5.
 If g:secure_modelines_leave_modeline is defined, the script will not
 clobber &modeline. Otherwise &modeline will be unset.
 
+If b:disable_secure_modelines is defined, securemodelines will not run for the
+current buffer. The intent being to turn off securemodelines in an ftplugin.
+
 Install into your plugin directory of choice.
 
 ==============================================================================

--- a/plugin/securemodelines.vim
+++ b/plugin/securemodelines.vim
@@ -124,6 +124,9 @@ fun! <SID>DoModeline(line) abort
 endfun
 
 fun! <SID>DoModelines() abort
+    if exists("b:disable_secure_modelines")
+        return
+    endif
     if line("$") > g:secure_modelines_modelines
         let l:lines={ }
         call map(filter(getline(1, g:secure_modelines_modelines) +


### PR DESCRIPTION
This PR allows disabling securemodelines in a given buffer via a new b:disable_secure_modelines variable.

My use case is that I use 'git commit -v' which includes changes to be committed; those changes can include a modeline, which can then be mistakenly interpreted by securemodelines as a modeline for the gitcommit buffer. By setting b:disable_secure_modelines in ftplugin/gitcommit.vim, this PR lets me disable securemodelines in gitcommit buffers.