### PR TITLE
Allow "(" and ")" to appear in option's value

### DIFF
--- a/after/plugin/securemodelines.vim
+++ b/after/plugin/securemodelines.vim
@@ -57,7 +57,7 @@ fun! <SID>IsInList(list, i) abort
 endfun
 
 fun! <SID>DoOne(item) abort
-    let l:matches = matchlist(a:item, '^\([a-z]\+\)\%([-+^]\?=[a-zA-Z0-9_\-,.\[\]]\+\)\?$')
+    let l:matches = matchlist(a:item, '^\([a-z]\+\)\%([-+^]\?=[a-zA-Z0-9_()\-,.\[\]]\+\)\?$')
     if len(l:matches) > 0
         if <SID>IsInList(g:secure_modelines_allowed_items, l:matches[1])
             exec "setlocal " . a:item


### PR DESCRIPTION
This is relevant for 'cinoptions' option (one of its values is `(0`).